### PR TITLE
Fixing OSX firmware dump script for OSX 10.11.2

### DIFF
--- a/firmware/extract_firmware_1.43_from_OSX_10.11.sh
+++ b/firmware/extract_firmware_1.43_from_OSX_10.11.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+IN=/System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface
+OUT=firmware.bin
+
+OSX_HASH=ccea5db116954513252db1ccb639ce95
+FW_HASH=4e1d11e205e5c55d128efa0029b268fe
+HASH=$(md5 -r $IN | awk '{ print $1 }')
+
+OFFSET=81920
+SIZE=603715
+
+if [ "$OSX_HASH" != "$HASH" ]
+then
+	echo -e "Mismatching driver hash for $IN ($HASH)"
+	echo -e "No firmware extracted!"
+	exit 1
+fi
+
+echo -e "Found matching hash ($HASH)"
+
+dd bs=1 skip=$OFFSET count=$SIZE if=$IN of=$OUT.gz &> /dev/null
+gunzip $OUT.gz
+
+RESULT=$(md5 -r $OUT | awk '{ print $1 }')
+
+if [ "$RESULT" != "$FW_HASH" ]
+then
+	echo -e "Firmware hash mismatch ($RESULT)"
+	echo -e "No firmware extracted!"
+	exit 1;
+fi
+
+echo -e "Firmware successfully extracted ($RESULT)"
+
+exit 0

--- a/firmware/extract_from_osx.sh
+++ b/firmware/extract_from_osx.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-IN=AppleCameraInterface
+IN=/System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface
 OUT=firmware.bin
 
-OSX_HASH=d1db66d71475687a5873dab10a345e2d
+OSX_HASH=ccea5db116954513252db1ccb639ce95
 FW_HASH=4e1d11e205e5c55d128efa0029b268fe
-HASH=$(md5sum $IN | awk '{ print $1 }')
+HASH=$(md5 -r $IN | awk '{ print $1 }')
 
 OFFSET=81920
 SIZE=603715
@@ -21,7 +21,7 @@ echo -e "Found matching hash ($HASH)"
 dd bs=1 skip=$OFFSET count=$SIZE if=$IN of=$OUT.gz &> /dev/null
 gunzip $OUT.gz
 
-RESULT=$(md5sum $OUT | awk '{ print $1 }')
+RESULT=$(md5 -r $OUT | awk '{ print $1 }')
 
 if [ "$RESULT" != "$FW_HASH" ]
 then


### PR DESCRIPTION
Use of md5 -r instead of md5sum (absent from vanilla OS X)
Proper OS_HASH
Exact path for IN variable to work with OS X 10.11.2
I think the default script should work without modification. For now those changes are listed in the Getting Started wiki.

Bear with me, this is my github learning path, and this is my first pull request.