### PR TITLE
Create OSX specific extract script

### DIFF
--- a/firmware/run_on_OSX_camera_firmware_extract.sh
+++ b/firmware/run_on_OSX_camera_firmware_extract.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Runs out of your existing OS X installation to dump the FacetimeHD camera firmware.
+# Tested on OS X 10.11.2
+#
+IN=/System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface
+OUT=firmware.bin
+
+OSX_HASH=ccea5db116954513252db1ccb639ce95
+FW_HASH=4e1d11e205e5c55d128efa0029b268fe
+HASH=$(md5 -r $IN | awk '{ print $1 }')
+
+OFFSET=81920
+SIZE=603715
+
+if [ "$OSX_HASH" != "$HASH" ]
+then
+	echo -e "Mismatching driver hash for $IN ($HASH)"
+	echo -e "No firmware extracted!"
+	exit 1
+fi
+
+echo -e "Found matching hash ($HASH)"
+
+dd bs=1 skip=$OFFSET count=$SIZE if=$IN of=$OUT.gz &> /dev/null
+gunzip $OUT.gz
+
+RESULT=$(md5 -r $OUT | awk '{ print $1 }')
+
+if [ "$RESULT" != "$FW_HASH" ]
+then
+	echo -e "Firmware hash mismatch ($RESULT)"
+	echo -e "No firmware extracted!"
+	exit 1;
+fi
+
+echo -e "Firmware successfully extracted ($RESULT)"
+
+exit 0


### PR DESCRIPTION
OS X 10.11 specific script:

Use of md5 -r instead of md5sum
Proper OSX_HASH value
Proper IN path for OS X

If you still have an OSX partition, it is likely the fastest way to get a copy of the camera firmware as of now.