### PR TITLE
Portable extraction

### DIFF
--- a/firmware/extract_from_osx.sh
+++ b/firmware/extract_from_osx.sh
@@ -2,9 +2,12 @@
 IN=AppleCameraInterface
 OUT=firmware.bin
 
+type md5sum > /dev/null 2>&1 && MD5="md5sum"
+type md5 > /dev/null 2>&1 && MD5="md5 -r"
+
 OSX_HASH=d1db66d71475687a5873dab10a345e2d
 FW_HASH=4e1d11e205e5c55d128efa0029b268fe
-HASH=$(md5sum $IN | awk '{ print $1 }')
+HASH=$($MD5 $IN | awk '{ print $1 }')
 
 OFFSET=81920
 SIZE=603715
@@ -16,12 +19,13 @@ then
 	exit 1
 fi
 
+
 echo -e "Found matching hash ($HASH)"
 
 dd bs=1 skip=$OFFSET count=$SIZE if=$IN of=$OUT.gz &> /dev/null
 gunzip $OUT.gz
 
-RESULT=$(md5sum $OUT | awk '{ print $1 }')
+RESULT=$($CMD $OUT | awk '{ print $1 }')
 
 if [ "$RESULT" != "$FW_HASH" ]
 then


### PR DESCRIPTION
Alters the script to work with `md5` or `md5sum`, whichever is available.

See #22
Closes #25