### PR TITLE
Firmware extraction update for Mac OS X 10.11.5

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,12 +1,12 @@
 SHELL = /bin/bash
 
-DMG:=osxupd10.11.3.dmg
+DMG:=osxupd10.11.5.dmg
 OSX_DRV:=AppleCameraInterface
 OSX_DRV_DIR:=System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS
 
-RANGE:=187085540-191012220
+RANGE:=205261917-208085450
 
-URL:=https://support.apple.com/downloads/DL1858/en_US/$(DMG)
+URL:=https://support.apple.com/downloads/DL1877/en_US/$(DMG)
 FILE:=$(OSX_DRV_DIR)/$(OSX_DRV)
 
 ifneq ("$(wildcard /usr/lib/firmware)", "")

--- a/firmware/extract-firmware.sh
+++ b/firmware/extract-firmware.sh
@@ -13,6 +13,7 @@ hash_drv_osx_140='387097b5133e980196ac51504a60ae1ad8bab736eb0070a55774925ca01948
 hash_drv_osx_143_1='4667e6828f6bfc690a39cf9d561369a525f44394f48d0a98d750931b2f3f278b'
 hash_drv_osx_143_2='d4650346c940dafdc50e5fcbeeeffe074ec359726773e79c0cfa601cec6b1f08'
 hash_drv_osx_143_3='dfac86799c6cf0aceb59bb4e732be8f030e7943eb1146830c7136f62621c9853'
+hash_drv_osx_143_4='f56e68a880b65767335071531a1c75f3cfd4958adc6d871adf8dbf3b788e8ee1'
 
 hash_fw_wnd_105='dabb8cf8e874451ebc85c51ef524bd83ddfa237c9ba2e191f8532b896594e50e'
 hash_fw_wnd_138='ed75dc37b1a0e19949e9e046a629cb55deb6eec0f13ba8fd8dd49b5ccd5a800e'
@@ -27,6 +28,7 @@ declare -A known_hashes=(
   ["$hash_drv_osx_143_1"]='OS X, El Capitan'
   ["$hash_drv_osx_143_2"]='OS X, El Capitan 10.11.2'
   ["$hash_drv_osx_143_3"]='OS X, El Capitan 10.11.3'
+  ["$hash_drv_osx_143_4"]='OS X, El Capitan 10.11.5'
 )
 
 # Offset in bytes of the firmware inside the driver
@@ -37,6 +39,7 @@ declare -A firmw_offsets=(
   ["$hash_drv_osx_143_1"]=81920
   ["$hash_drv_osx_143_2"]=81920
   ["$hash_drv_osx_143_3"]=81920
+  ["$hash_drv_osx_143_4"]=81920
 )
 
 # Size in bytes of the firmware inside the driver 
@@ -47,6 +50,7 @@ declare -A firmw_sizes=(
   ["$hash_drv_osx_143_1"]=603715
   ["$hash_drv_osx_143_2"]=603715
   ["$hash_drv_osx_143_3"]=603715
+  ["$hash_drv_osx_143_4"]=603715
 )
 
 # Compression method used to store the firmware inside the driver
@@ -57,6 +61,7 @@ declare -A compression=(
   ["$hash_drv_osx_143_1"]='gzip'
   ["$hash_drv_osx_143_2"]='gzip'
   ["$hash_drv_osx_143_3"]='gzip'
+  ["$hash_drv_osx_143_4"]='gzip'
 )
 
 declare -A firmw_hashes=(
@@ -238,17 +243,16 @@ decompress_dmg()
   msg2 "Extracting update package..."
   tail -c +189001729 "5.hfs" | head -c 661960661 > OSXUpd.xar
   rm -f "5.hfs"
-
   msg2 "Uncompressing XAR archive..."
   xar -x -f "OSXUpd.xar"
   rm -f "OSXUpd.xar"
 
   msg2 "Decoding Payload..."
   pbzx "OSXUpd"*.pkg"/Payload" > /dev/null
-  rm "OSXUpd10.11.3.pkg/Payload"
+  rm "OSXUpd10.11.5.pkg/Payload"
 
   msg2 "Decompressing archives..."
-  cd "OSXUpd10.11.3.pkg"
+  cd "OSXUpd10.11.5.pkg"
   find . -name "Payload.part*.xz" -exec xz --decompress --verbose {} \;
   cat "Payload.part"* | cpio -id &> /dev/null
   cp "./System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface" \


### PR DESCRIPTION
This patch set updates the firmware download and extraction scripts
to work with the OS X El Capitan 10.11.5 Update:

https://support.apple.com/downloads/DL1877
https://support.apple.com/downloads/DL1877/en_US/osxupd10.11.5.dmg

Signed-off-by: Jan Hilberath jan@hilberath.de
