### PR TITLE
Ratelimit firmware messages which can be quite spammy

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -28,6 +28,7 @@
 #include <linux/sched.h>
 #include <linux/wait.h>
 #include <linux/videodev2.h>
+#include <linux/ratelimit.h>
 #include "fthd_drv.h"
 #include "fthd_hw.h"
 #include "fthd_isp.h"
@@ -150,7 +151,7 @@ static void terminal_handler(struct fthd_private *dev_priv,
 	if (request_size > 512)
 		request_size = 512;
 	FTHD_S2_MEMCPY_FROMIO(buf, address, request_size);
-	pr_info("FWMSG: %.*s", request_size, buf);
+	pr_info_ratelimited("FWMSG: %.*s", request_size, buf);
 }
 
 static void buf_t2h_handler(struct fthd_private *dev_priv,


### PR DESCRIPTION
Otherwise, firmware messages can end up spamming dmesg much like:
```
        [  +0.033402] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033322] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033323] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033459] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033234] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033410] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033397] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.034869] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.031967] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033406] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033311] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033266] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033532] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033198] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.034350] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.032565] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033325] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033235] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033364] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033389] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033347] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033388] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033422] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033436] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033389] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.034295] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.032486] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
        [  +0.033251] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
```
This patch is used to ratelimit this.