### PR TITLE
firwmare: Add firmware_verbose to control firmware messages.

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -36,6 +36,12 @@
 #include "fthd_v4l2.h"
 #include "fthd_debugfs.h"
 
+bool firmware_verbose = FIRMWARE_VERBOSE;
+
+module_param(firmware_verbose, bool, 0644);
+MODULE_PARM_DESC(firmware_verbose,
+                   "Enable extremely verbose debugging messages from firmware to be emitted.");
+
 static int fthd_pci_reserve_mem(struct fthd_private *dev_priv)
 {
 	unsigned long start;
@@ -150,7 +156,8 @@ static void terminal_handler(struct fthd_private *dev_priv,
 	if (request_size > 512)
 		request_size = 512;
 	FTHD_S2_MEMCPY_FROMIO(buf, address, request_size);
-	pr_info("FWMSG: %.*s", request_size, buf);
+	if (firmware_verbose)
+		pr_info("FWMSG: %.*s", request_size, buf);
 }
 
 static void buf_t2h_handler(struct fthd_private *dev_priv,
@@ -546,7 +553,6 @@ static struct pci_driver fthd_pci_driver = {
 	.resume = fthd_pci_resume,
 #endif
 };
-
 module_pci_driver(fthd_pci_driver);
 
 MODULE_AUTHOR("Patrik Jakobsson <patrik.r.jakobsson@gmail.com>");

--- a/fthd_drv.h
+++ b/fthd_drv.h
@@ -37,6 +37,7 @@
 #define FTHD_PCI_ISP_IO 4
 
 #define FTHD_BUFFERS 4
+#define FIRMWARE_VERBOSE false
 
 enum FW_CHAN_TYPE {
 	FW_CHAN_TYPE_OUT=0,


### PR DESCRIPTION
This commit adds a firmware_verbose module parameter which controls
whether firmware messages, at any verbosity level, will be emitted or
not.

It is false by default.

This is to avoid clogging the dmesg with messages such as:

```
[  +0.033253] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033493] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033356] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033375] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033330] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033410] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033364] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033433] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033206] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033681] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033048] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033578] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033247] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
[  +0.033443] FWMSG: ERR: ./H4ISPCD/filters/IC/CImageCaptureH4.cpp, 777: FlowIC00: SIF errors: sifIrq = 0x8a!
```

Since it is emitted at Error level, changing printk debugging level is
of no avail here.
