### PR TITLE
Tweak Makefile to work with dkms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 facetimehd-objs := fthd_hw.o fthd_drv.o fthd_ringbuf.o fthd_isp.o fthd_v4l2.o fthd_buffer.o fthd_debugfs.o
 obj-m := facetimehd.o
 
+KVERSION := $(KERNELRELEASE)
+ifeq ($(origin KERNELRELEASE), undefined)
 KVERSION := $(shell uname -r)
+endif
 KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)
 


### PR DESCRIPTION
Specifically, allow building for an installed kernel that is not the running kernel