### PR TITLE
No need to include the extra slash in firmware's make install

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -42,8 +42,8 @@ $(OSX_DRV):
 	@rmdir -p "$(OSX_DRV_DIR)"
 
 install:
-	@echo "Copying firmware into '$(DESTDIR)/$(FW_DIR)'"
-	@install -dm755 "$(DESTDIR)/$(FW_DIR)"
+	@echo "Copying firmware into '$(DESTDIR)$(FW_DIR)'"
+	@install -dm755 "$(DESTDIR)$(FW_DIR)"
 	@install -m644 "firmware.bin" "$(DESTDIR)/$(FW_DIR)/firmware.bin"
 
 .PHONY: clean


### PR DESCRIPTION
`FW_DIR` is already prepended with `/`

Before:
`Copying firmware into '//lib/firmware/facetimehd'`

After:
`Copying firmware into '/lib/firmware/facetimehd'`