### PR TITLE
Fix compilation error with 4.19+ kernels

### DIFF
--- a/fthd_drv.h
+++ b/fthd_drv.h
@@ -24,6 +24,7 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 #include <linux/mutex.h>
+#include <linux/version.h>
 #include <media/videobuf2-dma-sg.h>
 #include <media/v4l2-device.h>
 #include <media/v4l2-ctrls.h>


### PR DESCRIPTION
make[1]: Entering directory '/usr/src/kernels/4.19.9-300.fc29.x86_64'
  CC [M]  bcwc_pcie/fthd_ddr.o
In file included from bcwc_pcie/fthd_ddr.c:21:
bcwc_pcie/fthd_drv.h:121:5: warning: "LINUX_VERSION_CODE" is not defined, evaluates to 0 [-Wundef]
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
     ^~~~~~~~~~~~~~~~~~
bcwc_pcie/fthd_drv.h:121:26: warning: "KERNEL_VERSION" is not defined, evaluates to 0 [-Wundef]
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
                          ^~~~~~~~~~~~~~
bcwc_pcie/fthd_drv.h:121:40: error: missing binary operator before token "("
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
...

Fixes the above compilation error

Signed-off-by: Numan Siddique <numan.siddique@gmail.com>