### PR TITLE
return 0 instead of -EINVAL when no filename found

### DIFF
--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -577,7 +577,7 @@ int fthd_isp_cmd_set_loadfile(struct fthd_private *dev_priv)
 	if (!filename) {
 		pr_err("no set file for sensorid %04x %04x found\n",
 		       dev_priv->sensor_id0, dev_priv->sensor_id1);
-		return -EINVAL;
+		return 0;
 	}
 
 	/* The set file is allowed to be missing but we don't get calibration */


### PR DESCRIPTION
My dev_priv->sensorid1 value is 0x248, which doesn't appear in the case statement. That said, the code below my change indicates that a set file itself is optional, so there should be no difference in behavior if the filename is not found or the filename is known but doesn't exist. The module and camera are functional on my machine with this change, with the caveat that no calibration is performed.