### PR TITLE
Fix build on 5.6 due to ioremap_nocache removal

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -70,19 +70,19 @@ static int fthd_pci_reserve_mem(struct fthd_private *dev_priv)
 	/* S2 IO */
 	start = pci_resource_start(dev_priv->pdev, FTHD_PCI_S2_IO);
 	len = pci_resource_len(dev_priv->pdev, FTHD_PCI_S2_IO);
-	dev_priv->s2_io = ioremap_nocache(start, len);
+	dev_priv->s2_io = ioremap(start, len);
 	dev_priv->s2_io_len = len;
 
 	/* S2 MEM */
 	start = pci_resource_start(dev_priv->pdev, FTHD_PCI_S2_MEM);
 	len = pci_resource_len(dev_priv->pdev, FTHD_PCI_S2_MEM);
-	dev_priv->s2_mem = ioremap_nocache(start, len);
+	dev_priv->s2_mem = ioremap(start, len);
 	dev_priv->s2_mem_len = len;
 
 	/* ISP IO */
 	start = pci_resource_start(dev_priv->pdev, FTHD_PCI_ISP_IO);
 	len = pci_resource_len(dev_priv->pdev, FTHD_PCI_ISP_IO);
-	dev_priv->isp_io = ioremap_nocache(start, len);
+	dev_priv->isp_io = ioremap(start, len);
 	dev_priv->isp_io_len = len;
 
 	pr_debug("Allocated S2 regs (BAR %d). %u bytes at 0x%p\n",


### PR DESCRIPTION
5.6 removed ioremap_nocache and other wrappers which are identical to ioremap. https://lkml.org/lkml/2020/1/27/585
Simply renaming and removing nocache fixes build for 5.6 which would otherwise fail when linking facetimehd.ko with undefined ioremap_nocache. It also doesn't break build on older kernels.