### PR TITLE
v4l2: omit wait_prepare/finish callbacks from vb2_ops for kernels >= 7.0

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -303,8 +303,10 @@ static struct vb2_ops vb2_queue_ops = {
 	.start_streaming        = fthd_start_streaming,
 	.stop_streaming         = fthd_stop_streaming,
 	.buf_queue              = fthd_buffer_queue,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	.wait_prepare           = vb2_ops_wait_prepare,
 	.wait_finish            = vb2_ops_wait_finish,
+#endif
 };
 
 static struct v4l2_file_operations fthd_vdev_fops = {


### PR DESCRIPTION
v7.0-rc1 commit b70886ff5833 ("media: vb2: drop wait_prepare/finish callbacks") has removed wait_prepare/wait_finish fields from struct vb2_ops, which fails the build with following errors:

  ```
    CC [M]  fthd_v4l2.o
  fthd_v4l2.c:306:10: error: ‘struct vb2_ops’ has no member named ‘wait_prepare’; did you mean ‘buf_prepare’?
    306 |         .wait_prepare           = vb2_ops_wait_prepare,
        |          ^~~~~~~~~~~~
        |          buf_prepare
  fthd_v4l2.c:306:35: error: ‘vb2_ops_wait_prepare’ undeclared here (not in a function)
    306 |         .wait_prepare           = vb2_ops_wait_prepare,
        |                                   ^~~~~~~~~~~~~~~~~~~~
  fthd_v4l2.c:307:10: error: ‘struct vb2_ops’ has no member named ‘wait_finish’
    307 |         .wait_finish            = vb2_ops_wait_finish,
        |          ^~~~~~~~~~~
  fthd_v4l2.c:307:35: error: ‘vb2_ops_wait_finish’ undeclared here (not in a function)
    307 |         .wait_finish            = vb2_ops_wait_finish,
        |                                   ^~~~~~~~~~~~~~~~~~~
  fthd_v4l2.c:307:35: warning: excess elements in struct initializer
  fthd_v4l2.c:307:35: note: (near initialization for ‘vb2_queue_ops’)
  make[3]: *** [/usr/src/linux-headers-7.0.0-3-generic/scripts/Makefile.build:289: fthd_v4l2.o] Error 1
  ```

Closes: #319