### PR TITLE
isp: enable sensor power via ACPI and make set file load non-fatal

### DIFF
--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -129,6 +129,16 @@ out:
 
 static int isp_enable_sensor(struct fthd_private *dev_priv)
 {
+	int ret;
+
+	/* Power on sensor CMOS via SMC; some systems may not have CMPE */
+	ret = isp_acpi_set_power(dev_priv, 1);
+	if (ret)
+		dev_warn(&dev_priv->pdev->dev,
+			 "ACPI sensor power-on failed (%d), continuing\n", ret);
+
+	mdelay(100); /* wait for sensor power rail to stabilize */
+
 	return 0;
 }
 
@@ -1261,9 +1271,6 @@ int isp_init(struct fthd_private *dev_priv)
 	ret = isp_load_firmware(dev_priv);
 	if (ret)
 		return ret;
-
-	isp_acpi_set_power(dev_priv, 1);
-	mdelay(20);
 
 	pci_set_power_state(dev_priv->pdev, PCI_D0);
 	mdelay(10);

--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -129,6 +129,16 @@ out:
 
 static int isp_enable_sensor(struct fthd_private *dev_priv)
 {
+	int ret;
+
+	/* Power on sensor CMOS via SMC; some systems may not have CMPE */
+	ret = isp_acpi_set_power(dev_priv, 1);
+	if (ret)
+		dev_warn(&dev_priv->pdev->dev,
+			 "ACPI sensor power-on failed (%d), continuing\n", ret);
+
+	mdelay(100); /* wait for sensor power rail to stabilize */
+
 	return 0;
 }
 
@@ -587,7 +597,11 @@ int fthd_isp_cmd_set_loadfile(struct fthd_private *dev_priv)
 	pr_debug("set file: addr %08lx, size %d\n", file->offset, (int)file->size);
 	cmd.addr = file->offset;
 	cmd.length = file->size;
-	return fthd_isp_cmd(dev_priv, CISP_CMD_CH_SET_FILE_LOAD, &cmd, sizeof(cmd), NULL);
+	ret = fthd_isp_cmd(dev_priv, CISP_CMD_CH_SET_FILE_LOAD, &cmd, sizeof(cmd), NULL);
+	if (ret)
+		dev_warn(&dev_priv->pdev->dev,
+			 "set file load failed (%d), continuing without calibration\n", ret);
+	return 0;
 }
 
 int fthd_isp_cmd_channel_info(struct fthd_private *dev_priv)
@@ -1261,9 +1275,6 @@ int isp_init(struct fthd_private *dev_priv)
 	ret = isp_load_firmware(dev_priv);
 	if (ret)
 		return ret;
-
-	isp_acpi_set_power(dev_priv, 1);
-	mdelay(20);
 
 	pci_set_power_state(dev_priv->pdev, PCI_D0);
 	mdelay(10);

--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -597,7 +597,11 @@ int fthd_isp_cmd_set_loadfile(struct fthd_private *dev_priv)
 	pr_debug("set file: addr %08lx, size %d\n", file->offset, (int)file->size);
 	cmd.addr = file->offset;
 	cmd.length = file->size;
-	return fthd_isp_cmd(dev_priv, CISP_CMD_CH_SET_FILE_LOAD, &cmd, sizeof(cmd), NULL);
+	ret = fthd_isp_cmd(dev_priv, CISP_CMD_CH_SET_FILE_LOAD, &cmd, sizeof(cmd), NULL);
+	if (ret)
+		dev_warn(&dev_priv->pdev->dev,
+			 "set file load failed (%d), continuing without calibration\n", ret);
+	return 0;
 }
 
 int fthd_isp_cmd_channel_info(struct fthd_private *dev_priv)


### PR DESCRIPTION
On MacBook Air (BCM1570), probe fails with error -5 because the ISP rejects CISP_CMD_CH_SET_FILE_LOAD with 0xfffe (UNKNOWN COMMAND).

`isp_enable_sensor()` was a no-op, now powers on the sensor CMOS via ACPI CMPE + 100 ms delay before ISP init
CISP_CMD_CH_SET_FILE_LOAD failure is now non-fatal, consistent with the existing comment "The set file is allowed to be missing"

Tested on MacBook Air A1466 (Mid 2013), Fedora 44, kernel 7.0.4.
Fixes #321.

```bash
$ uname -r modinfo facetimehd | grep -E "version|filename" journalctl -k | grep facetimehd

7.0.4-200.fc44.x86_64
filename:       /lib/modules/7.0.4-200.fc44.x86_64/extra/facetimehd/facetimehd.ko
May 10 01:16:36 fedora kernel: facetimehd: loading out-of-tree module taints kernel.
May 10 01:16:36 fedora kernel: facetimehd: module verification failed: signature and/or required key missing - tainting kernel
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Found FaceTime HD camera with device id: 1570
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Setting 64bit DMA mask
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: S2 PCIe link init succeeded
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Refclk: 25MHz (0xa)
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: PLL reset finished
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Waiting for S2 PLL to lock at 450 MHz
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: S2 PLL is locked after 10 us
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: S2 PLL is in bypass mode
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: DDR40 PHY PLL locked on safe settings
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: STRAP valid
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Configuring DDR PLLs for 450 MHz
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: DDR40 PLL is locked after 0 us
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: First DDR40 VDL calibration completed after 2 us
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Second DDR40 VDL calibration completed after 2 us
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Using step size 154
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: VDL set to: coarse=0x10008, fine=0x1011b
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Virtual VTT enabled
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: S2 DRAM memory address: 0x22159559
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Rewrite DDR mode registers succeeded
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Full memory verification succeeded! (0)
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Loaded firmware, size: 1392kb
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: ISP woke up after 0ms
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Number of IPC channels: 7, queue size: 44865
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Firmware requested heap size: 3072kb
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: ISP second int after 0ms
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Channel description table at 00800000
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: magic value: 00000000 after 0 ms
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: Enabling interrupts
May 10 01:16:36 fedora kernel: facetimehd 0000:02:00.0: set file load failed (-5), continuing without calibration
```