### PR TITLE
Enable the camera on the 12-inch MacBook (MacBook8,1)

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -439,6 +439,11 @@ static int fthd_firmware_start(struct fthd_private *dev_priv)
 	if (ret)
 		return ret;
 
+	/* Query the sensor's native resolution now so fthd_v4l2_register()
+	 * can advertise it. Non-fatal: if it fails the V4L2 layer falls back
+	 * to a default size. */
+	fthd_isp_cmd_channel_camera_config(dev_priv);
+
 	return fthd_isp_cmd_set_loadfile(dev_priv);
 
 }

--- a/fthd_drv.h
+++ b/fthd_drv.h
@@ -103,6 +103,11 @@ struct fthd_private {
 	int sensor_count;
 	int sensor_id0;
 	int sensor_id1;
+	/* Native sensor resolution, read from the firmware's per-channel camera
+	 * config. MacBookPro sensors report 1280x720; the 12-inch MacBook
+	 * (MacBook8,1, sensor 1675) reports 848x588. 0 until detected. */
+	unsigned int sensor_width;
+	unsigned int sensor_height;
 
 	struct fthd_fmt fmt;
 

--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -648,6 +648,22 @@ int fthd_isp_cmd_channel_camera_config(struct fthd_private *dev_priv)
 			break;
 		snprintf(prefix, sizeof(prefix)-1, "CAMCONF%d ", i);
 		print_hex_dump_bytes(prefix, DUMP_PREFIX_OFFSET, &cmd, sizeof(cmd));
+
+		/* The first two u16s of the config payload are the sensor's
+		 * native width and height (e.g. 1280x720 on MacBookPro,
+		 * 848x588 on the 12-inch MacBook). Record sensor 0's size so
+		 * the V4L2 layer can advertise the real resolution instead of
+		 * a hardcoded one. */
+		if (i == 0) {
+			unsigned int w = cmd.data[0] | (cmd.data[1] << 8);
+			unsigned int h = cmd.data[2] | (cmd.data[3] << 8);
+
+			if (w && h) {
+				dev_priv->sensor_width = w;
+				dev_priv->sensor_height = h;
+				pr_debug("sensor native resolution: %ux%u\n", w, h);
+			}
+		}
 	}
 	return ret;
 }
@@ -1115,16 +1131,15 @@ int fthd_start_channel(struct fthd_private *dev_priv, int channel)
 	if (ret)
 		return ret;
 
-	if (dev_priv->fmt.fmt.width < 1280 ||
-	    dev_priv->fmt.fmt.height < 720) {
-		x1 = 160;
-		x2 = 960;
-	} else {
-		x1 = 0;
-		x2 = 1280;
-	}
+	/* Crop the full sensor area. The 12-inch MacBook (MacBook8,1, sensor
+	 * 1675) reports an 848x588 sensor via CISP_CMD_CH_CAMERA_CONFIG_GET;
+	 * the old hardcoded 1280x720 crop exceeds that array and makes the
+	 * sensor interface throw SIF errors. Use the negotiated format size. */
+	x1 = 0;
+	x2 = dev_priv->fmt.fmt.width;
 
-	ret = fthd_isp_cmd_channel_crop_set(dev_priv, 0, x1, 0, x2, 720);
+	ret = fthd_isp_cmd_channel_crop_set(dev_priv, 0, x1, 0, x2,
+					    dev_priv->fmt.fmt.height);
 	if (ret)
 		return ret;
 

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -25,6 +25,8 @@
 #include "fthd_ringbuf.h"
 #include "fthd_buffer.h"
 
+/* Fallback ceiling used only if the sensor's native size wasn't detected.
+ * The real per-device limit is dev_priv->sensor_width/height. */
 #define FTHD_MAX_WIDTH 1280
 #define FTHD_MAX_HEIGHT 720
 #define FTHD_MIN_WIDTH 320
@@ -405,18 +407,24 @@ static int fthd_v4l2_adjust_format(struct fthd_private *dev_priv,
 				   struct v4l2_pix_format *pix)
 {
 
+	/* Upper bound is the sensor's native resolution (e.g. 1280x720 on
+	 * MacBookPro, 848x588 on the 12-inch MacBook); fall back to the generic
+	 * ceiling if it hasn't been detected yet. */
+	unsigned int max_w = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
+	unsigned int max_h = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
+
 	if (pix->pixelformat != V4L2_PIX_FMT_YUYV &&
 	    pix->pixelformat != V4L2_PIX_FMT_YVYU)
 		pix->pixelformat = V4L2_PIX_FMT_YUYV;
 
 	if (pix->width < FTHD_MIN_WIDTH)
 		pix->width = FTHD_MIN_WIDTH;
-	if (pix->width > FTHD_MAX_WIDTH)
-		pix->width = FTHD_MAX_WIDTH;
+	if (pix->width > max_w)
+		pix->width = max_w;
 	if (pix->height < FTHD_MIN_HEIGHT)
 		pix->height = FTHD_MIN_HEIGHT;
-	if (pix->height > FTHD_MAX_HEIGHT)
-		pix->height = FTHD_MAX_HEIGHT;
+	if (pix->height > max_h)
+		pix->height = max_h;
 
 	pix->colorspace = V4L2_COLORSPACE_SRGB;
 	pix->field = V4L2_FIELD_NONE;
@@ -543,6 +551,8 @@ static int fthd_v4l2_ioctl_s_parm(struct file *filp, void *priv,
 static int fthd_v4l2_ioctl_enum_framesizes(struct file *filp, void *priv,
 		struct v4l2_frmsizeenum *sizes)
 {
+	struct fthd_private *dev_priv = video_drvdata(filp);
+
 	if (sizes->index)
 		return -EINVAL;
 
@@ -551,8 +561,8 @@ static int fthd_v4l2_ioctl_enum_framesizes(struct file *filp, void *priv,
 		return -EINVAL;
 
 	sizes->type = V4L2_FRMSIZE_TYPE_DISCRETE;
-	sizes->discrete.width = FTHD_MAX_WIDTH;
-	sizes->discrete.height = FTHD_MAX_HEIGHT;
+	sizes->discrete.width  = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
+	sizes->discrete.height = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
 
 	return 0;
 }
@@ -560,6 +570,10 @@ static int fthd_v4l2_ioctl_enum_framesizes(struct file *filp, void *priv,
 static int fthd_v4l2_ioctl_enum_frameintervals(struct file *filp, void *priv,
 		struct v4l2_frmivalenum *interval)
 {
+	struct fthd_private *dev_priv = video_drvdata(filp);
+	unsigned int max_w = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
+	unsigned int max_h = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
+
 	pr_debug("%s\n", __FUNCTION__);
 
 	if (interval->index)
@@ -571,8 +585,8 @@ static int fthd_v4l2_ioctl_enum_frameintervals(struct file *filp, void *priv,
 		return -EINVAL;
 
 	if (interval->width & 7
-	    || interval->width > FTHD_MAX_WIDTH
-	    || interval->height > FTHD_MAX_HEIGHT)
+	    || interval->width > max_w
+	    || interval->height > max_h)
 		return -EINVAL;
 
 	interval->type = V4L2_FRMIVAL_TYPE_DISCRETE;
@@ -742,10 +756,12 @@ int fthd_v4l2_register(struct fthd_private *dev_priv)
 		video_device_release(vdev);
 		goto fail_vdev;
 	}
-	dev_priv->fmt.fmt.sizeimage = 1280 * 720 * 2;
+	/* Default to the sensor's native resolution (detected at probe), or the
+	 * generic ceiling if detection didn't run. */
+	dev_priv->fmt.fmt.width  = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
+	dev_priv->fmt.fmt.height = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
 	dev_priv->fmt.fmt.pixelformat = V4L2_PIX_FMT_YUYV;
-	dev_priv->fmt.fmt.width = 1280;
-	dev_priv->fmt.fmt.height = 720;
+	dev_priv->fmt.fmt.sizeimage = dev_priv->fmt.fmt.width * dev_priv->fmt.fmt.height * 2;
 	dev_priv->fmt.planes = 1;
 
 	fthd_v4l2_adjust_format(dev_priv, &dev_priv->fmt.fmt);

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -510,10 +510,14 @@ static int fthd_v4l2_ioctl_s_fmt_vid_cap(struct file *filp, void *priv,
 static int fthd_v4l2_ioctl_g_parm(struct file *filp, void *priv,
 		struct v4l2_streamparm *parm)
 {
-        struct fthd_private *priv_dev = video_drvdata(filp);
+	/* Report a consistent 30 fps, matching what the sensor actually delivers
+	 * and what enum_frameintervals advertises. The old frametime/1000 value
+	 * (25 fps) disagreed with the real 30 fps rate, which made GStreamer's
+	 * pipewiresrc compute negative frame durations and stall after one frame
+	 * (e.g. GNOME Snapshot froze, while ffplay/v4l2-ctl were unaffected). */
 	struct v4l2_fract timeperframe = {
-		.numerator = priv_dev->frametime,
-		.denominator = 1000,
+		.numerator = 1,
+		.denominator = 30,
 	};
 
 	if (parm->type != V4L2_BUF_TYPE_VIDEO_CAPTURE)


### PR DESCRIPTION
Detects the sensor's native resolution from firmware instead of hardcoding 1280×720 — fixes the SIF errors: sifIrq=0x804 that have kept the 12-inch MacBook (MacBook8,1, sensor 1675, 848×588) from ever streaming, while leaving MacBookPro 1280×720 unaffected via detect-or-fallback. 

Second commit reports a consistent 30 fps so GStreamer/PipeWire apps don't stall after one frame. Resolves #196, #58.

Full disclosure - I used Claude to bat this back and forth. I realise this hardware is likely to recieve any meaningful effort anymore, so I hope this helps someone at least.