### PR TITLE
Two small cleanups: missing break and a hardcoded buffer count

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -79,8 +79,8 @@ static int fthd_buffer_queue_setup(
 	}
 
 	*nbuffers = (4096 * 4096) / total_size;
-	if (*nbuffers > 4)
-		*nbuffers = 4;
+	if (*nbuffers > FTHD_BUFFERS)
+		*nbuffers = FTHD_BUFFERS;
 	if (*nbuffers <= 1)
 		return -ENOMEM;
 	pr_debug("using %d buffers\n", *nbuffers);

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -669,7 +669,7 @@ static int fthd_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 	case V4L2_CID_AUTO_WHITE_BALANCE:
 		ret = fthd_isp_cmd_channel_awb(dev_priv, 0, ctrl->val);
-
+		break;
 	default:
 		break;
 


### PR DESCRIPTION
Two independent cleanups. Neither changes anything at the current values.

*(Edited 23 August: this used to carry a third commit, `isp: sleep instead of spinning for a second while AE settles`. It was identical to the first commit of #334 — same change, same `patch-id` — so whichever of the two merged first made the other conflict. Dropped here; it lives in #334, which is where the rest of that argument is.)*

**`v4l2: add the missing break after the auto white balance case`**

`fthd_s_ctrl()` falls through from `V4L2_CID_AUTO_WHITE_BALANCE` into the next case. Harmless as things stand, because `default` does nothing — but it is an implicit fallthrough the compiler is entitled to warn about, and it becomes a trap the moment anything is added to `default` or a case is added below it.

**`v4l2: cap the buffer count with FTHD_BUFFERS, not a literal 4`**

`fthd_buffer_queue_setup()` clamps the buffer count with a hardcoded 4, while `h2t_bufs[]` is sized `FTHD_BUFFERS` and every other user of that array goes through the constant. The two agree today, so nothing changes.

What the literal costs is that `FTHD_BUFFERS` stops meaning what it says: raising it grows the array but leaves the queue capped at 4, so the extra entries are unreachable; lowering it below 4 lets `queue_setup()` hand out more vb2 buffers than there are entries, and `fthd_buffer_prepare()` then fails the surplus with `-ENOBUFS` at `VIDIOC_QBUF`, which reads as the camera refusing to stream for no visible reason. The literal has been there since f3067f2, the commit that introduced `FTHD_BUFFERS`, so it looks like one substitution that was missed.

Tested on a MacBookPro14,1 (FaceTime HD, device id 1570). Both build clean with no new warnings.

---

### The series

Seven PRs on this driver, all on master (`364b1c6`), all found while debugging a camera problem on a MacBookPro14,1:

| | |
|---|---|
| **#328 (this one)** | two small cleanups: missing `break`, hardcoded buffer count |
| #329 | control values discarded at every `VIDIOC_STREAMON` |
| #330 | `cmd.y1` never assigned in the crop command — one line |
| #331 | `ALIGN(width, 7)` aligns nothing; second commit re-does 545cb18 and **should wait** |
| #332 | one firmware timeout leaves the driver with no usable buffers |
| #333 | the camera writes in front of any buffer that is not page aligned |
| #334 | the auto-exposure wait: 1000 ms → 200 ms |

They can be taken in any order, with one exception: **the second commit of #331 should not be taken yet** — reasons in that PR.

*(Until 23 August there was a second exception: #328 and #334 both carried the same `mdelay` → `msleep` commit, so whichever merged first made the other conflict. I have dropped it from #328; it lives in #334. The seven are now independent of each other.)*

There is one more patch not sent yet: the channel-start crop returns the top left corner of the frame at any size below the sensor. It is measured and ready, and it sits on top of #330. I am holding it back rather than adding an eighth PR to the pile.
