### PR TITLE
isp: assign y1 in the crop command

### DIFF
--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -707,7 +707,7 @@ int fthd_isp_cmd_channel_crop_set(struct fthd_private *dev_priv, int channel,
 	memset(&cmd, 0, sizeof(cmd));
 	cmd.channel = channel;
 	cmd.x1 = x1;
-	cmd.y2 = y2;
+	cmd.y1 = y1;
 	cmd.x2 = x2;
 	cmd.y2 = y2;
 	len = sizeof(cmd);


### PR DESCRIPTION
`fthd_isp_cmd_channel_crop_set()` writes `cmd.y2` twice and never writes `cmd.y1`, so the `y1` argument is silently dropped:

```c
cmd.x1 = x1;
cmd.y2 = y2;    /* should be y1 */
cmd.x2 = x2;
cmd.y2 = y2;
```

One line. Latent today because the only caller passes 0, but the parameter cannot be used until this is fixed — which is why it comes first, ahead of the crop rewrite that needs it.

---

### The series

Seven PRs on this driver, all on master (`364b1c6`), all found while debugging a camera problem on a MacBookPro14,1:

| | |
|---|---|
| #328 | two small cleanups: missing `break`, hardcoded buffer count |
| #329 | control values discarded at every `VIDIOC_STREAMON` |
| **#330 (this one)** | `cmd.y1` never assigned in the crop command — one line |
| #331 | `ALIGN(width, 7)` aligns nothing; second commit re-does 545cb18 and **should wait** |
| #332 | one firmware timeout leaves the driver with no usable buffers |
| #333 | the camera writes in front of any buffer that is not page aligned |
| #334 | the auto-exposure wait: 1000 ms → 200 ms |

They can be taken in any order, with one exception: **the second commit of #331 should not be taken yet** — reasons in that PR.

*(Until 23 August there was a second exception: #328 and #334 both carried the same `mdelay` → `msleep` commit, so whichever merged first made the other conflict. I have dropped it from #328; it lives in #334. The seven are now independent of each other.)*

There is one more patch not sent yet: the channel-start crop returns the top left corner of the frame at any size below the sensor. It is measured and ready, and it sits on top of #330. I am holding it back rather than adding an eighth PR to the pile.
